### PR TITLE
Endpoint PUT /complete

### DIFF
--- a/lib/views/init.erb
+++ b/lib/views/init.erb
@@ -93,5 +93,8 @@ echo 'StrictHostKeyChecking no' > /root/.ssh/config
 
 git clone -b <%= chef_branch %> <%= chef_repo %> /root/ops
 echo '<%= json %>' > /root/init.json
+
+# TODO: add a loop check here if exitcode != 0
 chef-solo -c /root/ops/cookbooks/init.rb -j /root/init.json -E <%= chef_environment %> && \
     (rm /root/.ssh/id_rsa; userdel -r ubuntu; rm -rf /root/.ssh; rm -rf /root/ops)
+# TODO: call /complete endpoint with the return code above


### PR DESCRIPTION
Sometimes the "apt" part of the provisioning process ends up not fine.
Basically would be nice to ensure a looong retry when the `apt-get update` phase takes ages, then chefun again and ensure docker gets installed (with runcmd on the role) and/or the server-agent restarted.

The solution is to change the way the gaptool does the bootstrap.

The gaptool runs chef-solo on bootstrap as a fire-and-forget action[0].

1. wrap a loop there and if  `exitcode != 0`, retry (up to N time then fail)

2. Add an endpoint to the gaptool so it knows when a machine ends the bootstrapping phase.

  Right now we have a `/init` that is called by the client to spawn a machine, then a `/register` that the machine calls back[1]  as a first thing of the boostrap phase. 

  The `/register` endpoint returns the script that then runs chef, which the machine executes. The idea is to add a third endpoint that the bootstrap script calls after running chef (either when chef succeed and when chef fails all N attempts).

3. If a machine calls the new `/complete` endpoint with error, or after a sane timeout (58 minutes, so we don't get in the new hour and we pay just for the first) -- kill the machine, raise an airbrake.

_(it sightly trickier than described above, we have to  pass a token/secret to avoid spurious calls to the `/complete` endpoint, similar to what `/register` does...)_

[0] https://github.com/Gild/gaptool-server/blob/master/lib/views/init.erb#L96
[1] https://github.com/Gild/gaptool-server/blob/master/lib/routes.rb#L43